### PR TITLE
Add max message size attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ See `attributes/default.rb` for default values.
   template statements in `35-server-per-host.conf`. Default value is
   the previous cookbook version's value, to preserve compatibility.
   See __server__ recipe below.
-
+* `node['rsyslog']['max_message_size']` - Specify the maximum allowed
+  message size. Default is 2k.
 
 Recipes
 =======

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,4 @@ default["rsyslog"]["server_ip"]     = nil
 default["rsyslog"]["server_search"] = "role:loghost"
 default["rsyslog"]["remote_logs"]   = true
 default["rsyslog"]["per_host_dir"]  = "%$YEAR%/%$MONTH%/%$DAY%/%HOSTNAME%"
+default["rsyslog"]["max_message_size"] = "2k"

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -3,6 +3,10 @@
 #			For more information see
 #			/usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
 
+#
+# Set max message size
+#
+$MaxMessageSize <%= node['rsyslog']['max_message_size'] %>
 
 #################
 #### MODULES ####


### PR DESCRIPTION
To enable the flexibility to customize the max message size that you desire to allow.  Default is 2k, and it may be useful to flex higher (or lower) in certain circumstances depending on deployment.
