### PR TITLE
Allow custom conf options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,3 +47,4 @@ when "ubuntu"
 when "arch"
   default["rsyslog"]["service_name"] = "rsyslogd"
 end
+default["rsyslog"]["forward_custom_config"] = {}

--- a/templates/default/49-remote.conf.erb
+++ b/templates/default/49-remote.conf.erb
@@ -4,3 +4,6 @@
 <% when "udp" -%>
 *.* @<%= @server %>:<%= node['rsyslog']['port'] %>
 <% end -%>
+<% node.rsyslog["forward_custom_config"].sort.each do |key, value| %>
+<%= key %>: <%= value %>
+<% end %>


### PR DESCRIPTION
This will allow you to provide an attribute key pair for custom values to be
inserted into the template that aren't already predefined.
