### PR TITLE
[COOK-3446] Added failsafe IP

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -36,7 +36,8 @@ else
 end
 
 if rsyslog_servers.empty?
-  Chef::Application.fatal!('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search!')
+  Chef::Log.warn('The rsyslog::client recipe was unable to determine the remote syslog server. Checked both the server_ip attribute and search!')
+  rsyslog_server = "127.0.0.1"
 end
 
 remote_type = node['rsyslog']['use_relp'] ? 'relp' : 'remote'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3446

Changed the rsyslog_server.empty? block to not kill the chef-client run, rather log the issue, and set a localhost IP for rsyslog server. This will allow chef to complete.
