### PR TITLE
[COOK-3876] Cate for setting rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['logs_to_forward']` -  Specifies what logs should be sent to the remote rsyslog server. Default is all ( \*.\* ).
 * `node['rsyslog']['default_log_dir']` - log directory used in `50-default.conf` template, defaults to `/var/log`
 * `node['rsyslog']['default_facility_logs']` - Hash containing log facilities and destinations used in `50-default.conf` template.
+* `node['rsyslog']['rate_limit_interval']` - Value of the $SystemLogRateLimitInterval configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
+* `node['rsyslog']['rate_limit_burst']` - Value of the $SystemLogRateLimitBurst configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
+
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,8 @@ default['rsyslog']['repeated_msg_reduction']    = 'on'
 default['rsyslog']['logs_to_forward']           = '*.*'
 default['rsyslog']['enable_imklog']             = true
 default['rsyslog']['config_prefix']             = '/etc'
+default['rsyslog']['rate_limit_interval']       = nil
+default['rsyslog']['rate_limit_burst']          = nil
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -67,6 +67,19 @@ $Umask 0022
 $PrivDropToUser <%= node['rsyslog']['user'] %>
 $PrivDropToGroup <%= node['rsyslog']['group'] %>
 <% end %>
+<% unless node['rsyslog']['rate_limit_interval'].nil? %>
+#
+# Set the amount of time that is being measured for rate limiting
+#
+$SystemLogRateLimitInterval <%= node['rsyslog']['rate_limit_interval'] %>
+<% end %>
+<% unless node['rsyslog']['rate_limit_burst'].nil? %>
+#
+# Set the amount of messages, that have to occur in the time limit of
+#   SystemLogRateLimitInterval, to trigger rate limiting
+#
+$SystemLogRateLimitBurst <%= node['rsyslog']['rate_limit_burst'] %>
+<% end %>
 #
 # Include all config files in <%= node['rsyslog']['config_prefix'] %>/rsyslog.d/
 #


### PR DESCRIPTION
Allow the optional setting of the following directives in rsyslog.conf:

$SystemLogRateLimitInterval
$SystemLogRateLimitBurst
