### PR TITLE
[COOK-4022] Add use_local_ipv4 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See `attributes/default.rb` for default values.
 * `node['rsyslog']['logs_to_forward']` -  Specifies what logs should be sent to the remote rsyslog server. Default is all ( \*.\* ).
 * `node['rsyslog']['default_log_dir']` - log directory used in `50-default.conf` template, defaults to `/var/log`
 * `node['rsyslog']['default_facility_logs']` - Hash containing log facilities and destinations used in `50-default.conf` template.
+* `node['rsyslog']['use_local_ipv4']` - Whether or not to make use the remote local IPv4 address on cloud systems when searching for servers (where available).  Default is 'false'.
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,7 @@ default['rsyslog']['repeated_msg_reduction']    = 'on'
 default['rsyslog']['logs_to_forward']           = '*.*'
 default['rsyslog']['enable_imklog']             = true
 default['rsyslog']['config_prefix']             = '/etc'
+default['rsyslog']['use_local_ipv4']            = false
 
 # The most likely platform-specific attributes
 default['rsyslog']['service_name']              = 'rsyslog'

--- a/metadata.rb
+++ b/metadata.rb
@@ -87,3 +87,8 @@ attribute 'rsyslog/priv_seperation',
   :display_name => 'Privilege separation',
   :description => 'Whether or not to make use of Rsyslog privilege separation',
   :default => 'false'
+
+attribute 'rsyslog/use_local_ipv4',
+  :display_name => 'Try to use local IPv4 address',
+  :description => 'Whether or not to make use the remote local IPv4 address on cloud systems when searching for servers (where available).',
+  :default => 'false'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -31,7 +31,15 @@ if Chef::Config[:solo]
     Chef::Application.fatal!("Chef Solo does not support search. You must set node['rsyslog']['server_ip']!")
   end
 else
-  results = search(:node, node['rsyslog']['server_search']).map { |n| n['ipaddress'] }
+  results = search(:node, node['rsyslog']['server_search']).map do |server|
+    ipaddress = server['ipaddress']
+    # If both server and client are on the same cloud and local network, they may be
+    # instructed to communicate via the internal interface by enabling `use_local_ipv4`
+    if node['rsyslog']['use_local_ipv4'] && server.attribute?('cloud') && server['cloud']['local_ipv4']
+      ipaddress = server['cloud']['local_ipv4']
+    end
+    ipaddress
+  end
   rsyslog_servers = Array(node['rsyslog']['server_ip']) + Array(results)
 end
 


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4022

For systems that populate `node['cloud']['local_ipv4']`, add a setting
`use_local_ipv4` to select the internal interface when adding remote servers
via search.
