### PR TITLE
Fixes broken tests for suse and adds in license accept (travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,3 +61,4 @@ matrix:
       env:
         - UNIT_AND_LINT=1
         - CHEF_FIPS=''
+        - CHEF_LICENSE=accept

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -93,7 +93,7 @@ end
 
 # platform family specific attributes
 case node['platform_family']
-when 'suse'
+when 'suse', 'opensuseleap'
   default['rsyslog']['service_name'] = 'syslog'
   default['rsyslog']['group'] = 'root'
   default['rsyslog']['default_facility_logs'] = {

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,7 +14,7 @@ platforms:
   - name: debian-9
   - name: debian-10
   - name: fedora-29
-  - name: opensuse-leap-42
+  - name: opensuse-leap-15
   - name: ubuntu-14.04
   - name: ubuntu-16.04
 


### PR DESCRIPTION
This commit removes opensuse leap 42 as it is no longer supported and
replaces it with opensuse leap 15.

It also adds in opensuseleap to the platform family specific
attributes alongside suse so that the correct attributes are used in the
recipe when the platform_family is opensuseleap.

It also adds in CHEF_LICENSE=accept for the last travis tests.

Signed-off-by: Rudi Kramer <rudi.kramer@fnb.co.za>

### Description

This fixes the remaining broken tests on travis ci.

### Issues Resolved

https://github.com/chef-cookbooks/rsyslog/issues/156

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
