### PR TITLE
Add facility to choose TLS driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['rate_limit_burst']` - Value of the $SystemLogRateLimitBurst configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
 - `node['rsyslog']['action_queue_max_disk_space']` - Max amount of disk space the disk-assisted queue is allowed to use ([more info](http://www.rsyslog.com/doc/queues.html)).
 - `node['rsyslog']['enable_tls']` - Whether or not to enable TLS encryption. When enabled, forces protocol to `tcp`. Default is `false`.
+- `node['rsyslog']['tls_driver']` -  Defaults to `ossl`.
 - `node['rsyslog']['tls_ca_file']` - Path to TLS CA file. Required for both server and clients.
 - `node['rsyslog']['tls_certificate_file']` - Path to TLS certificate file. Required for server, optional for clients.
 - `node['rsyslog']['tls_key_file']` - Path to TLS key file. Required for server, optional for clients.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['rsyslog']['default_remote_template']   = nil
 default['rsyslog']['rate_limit_interval']       = nil
 default['rsyslog']['rate_limit_burst']          = nil
 default['rsyslog']['enable_tls']                = false
+default['rsyslog']['tls_driver']                = 'ossl'
 default['rsyslog']['action_queue_max_disk_space'] = '1G'
 default['rsyslog']['tls_ca_file']               = nil
 default['rsyslog']['tls_certificate_file']      = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,15 @@
 package node['rsyslog']['package_name']
 package rsyslog_relp_package if node['rsyslog']['use_relp']
 
+if node['rsyslog']['enable_tls']
+  case node['rsyslog']['tls_driver']
+  when 'gtls'
+    package "#{node['rsyslog']['package_name']}-gnutls"
+  when 'ossl'
+    package "#{node['rsyslog']['package_name']}-openssl"
+  end
+end
+
 if node['rsyslog']['enable_tls'] && node['rsyslog']['tls_ca_file']
   raise "Recipe rsyslog::default can not use 'enable_tls' with protocol '#{node['rsyslog']['protocol']}' (requires 'tcp')" unless node['rsyslog']['protocol'] == 'tcp'
   package "#{node['rsyslog']['package_name']}-gnutls"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -18,7 +18,7 @@
 #
 
 # Manually set this attribute
-node.default['rsyslog']['server'] = true
+node.override['rsyslog']['server'] = true
 
 include_recipe 'rsyslog::default'
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -101,7 +101,7 @@ describe 'rsyslog::server' do
     context 'on SmartOS' do
       cached(:chef_run) do
         ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11') do |node|
-          node.normal['rsyslog']['server'] = false
+          node.override['rsyslog']['server'] = false
         end.converge(described_recipe)
       end
 

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -35,7 +35,7 @@ $ModLoad <%= mod %>
 <% if node['rsyslog']['server'] -%>
   <% if node['rsyslog']['enable_tls'] && node['rsyslog']['tls_ca_file'] &&
         node['rsyslog']['tls_key_file'] && node['rsyslog']['tls_certificate_file'] -%>
-$DefaultNetstreamDriver gtls
+$DefaultNetstreamDriver <%= node['rsyslog']['tls_driver'] %>
 $DefaultNetstreamDriverCAFile <%= node['rsyslog']['tls_ca_file'] %>
 $DefaultNetstreamDriverCertFile <%= node['rsyslog']['tls_certificate_file'] %>
 $DefaultNetstreamDriverKeyFile <%= node['rsyslog']['tls_key_file'] %>


### PR DESCRIPTION
Add node attribute for TLS driver
Add TLS driver package installation
Add the attribute to rsyslog.conf template

Signed-off-by: Alex Markelov <alex@markelov.org>

### Description

The change allows to choose between GnuTLS and OpenSSL TLS drivers. Without the change only GnuTLS can be used.

### Issues Resolved

rsyslog has a bug in GnuTLS driver, see <https://github.com/rsyslog/rsyslog/issues/2547> whereby server's full chain of trust is not exposed to clients and breaks TLS handshake. Switching to OpenSSL driver fixes the issue.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
