### PR TITLE
Fix log directory ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See `attributes/default.rb` for default values.
 
 - `node['rsyslog']['log_dir']` - If the node is an rsyslog server, this specifies the directory where the logs should be stored.
 - `node['rsyslog']['working_dir']` - The temporary working directory where messages are buffered
+- `node['rsyslog']['working_dir_mode']` - The temporary working directory access mode
 - `node['rsyslog']['server']` - Determined automatically and set to true on the server.
 - `node['rsyslog']['server_ip']` - If not defined then search will be used to determine rsyslog server. Default is `nil`. This can be a string or an array.
 - `node['rsyslog']['server_search']` - Specify the criteria for the server search operation. Default is `role:loghost`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default['rsyslog']['local_host_name']           = nil
 default['rsyslog']['default_log_dir']           = '/var/log'
 default['rsyslog']['log_dir']                   = '/srv/rsyslog'
 default['rsyslog']['working_dir']               = '/var/spool/rsyslog'
+default['rsyslog']['working_dir_mode']          = '0700'
 default['rsyslog']['server']                    = false
 default['rsyslog']['use_relp']                  = false
 default['rsyslog']['relp_port']                 = 20_514
@@ -82,6 +83,7 @@ default['rsyslog']['config_dir']['mode']        = '0755'
 case node['platform']
 when 'ubuntu'
   default['rsyslog']['user'] = 'syslog'
+  default['rsyslog']['dir_owner'] = 'syslog'
   default['rsyslog']['group'] = 'adm'
   default['rsyslog']['priv_seperation'] = true
   default['rsyslog']['priv_group'] = 'syslog'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,15 +35,15 @@ if node['rsyslog']['enable_tls'] && node['rsyslog']['tls_ca_file']
 end
 
 directory "#{node['rsyslog']['config_prefix']}/rsyslog.d" do
-  owner 'root'
-  group 'root'
+  owner node['rsyslog']['config_files']['owner']
+  group node['rsyslog']['config_files']['group']
   mode  node['rsyslog']['config_dir']['mode']
 end
 
 directory node['rsyslog']['working_dir'] do
   owner node['rsyslog']['user']
   group node['rsyslog']['group']
-  mode  '0700'
+  mode  node['rsyslog']['working_dir_mode']
   recursive true
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,9 +23,9 @@ node.override['rsyslog']['server'] = true
 include_recipe 'rsyslog::default'
 
 directory node['rsyslog']['log_dir'] do
-  owner    node['rsyslog']['user']
-  group    node['rsyslog']['group']
-  mode     '0755'
+  owner    node['rsyslog']['dir_owner']
+  group    node['rsyslog']['dir_group']
+  mode     node['rsyslog']['dir_create_mode']
   recursive true
 end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -22,7 +22,7 @@ describe 'rsyslog::server' do
       expect(chef_run).to create_directory('/srv/rsyslog')
     end
 
-    it 'is owned by root:root' do
+    it 'is owned by syslog:adm' do
       expect(directory.owner).to eq('syslog')
       expect(directory.group).to eq('adm')
     end


### PR DESCRIPTION
Add `working_dir_mode` attribute to specify working directory access mode
Fix hardcoded root ownership of logs directory
Fix typo in unit test

Signed-off-by: Alex Markelov <alex@markelov.org>

# Description

Recipe doesn't use already defined node attributes to set ownership of logs directory.
Adding 'working_dir_mode' attribute to control working directory access mode instead of using hardcoded value.

## Issues Resolved

None

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
