### PR TITLE
FreeBSD does not have a separate package for relp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the rsyslog cookbook.
 
 ## Unreleased
 
+- Add check for FreeBSD to prevent trying to install a RELP package
+
 ## 8.0.1 - *2021-01-04*
 
 - Cookstyle Bot Auto Corrections with Cookstyle 7.5.3

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 package node['rsyslog']['package_name']
-package rsyslog_relp_package if node['rsyslog']['use_relp']
+package rsyslog_relp_package if node['rsyslog']['use_relp'] && !platform_family?('freebsd')
 
 if node['rsyslog']['enable_tls']
   case node['rsyslog']['tls_driver']


### PR DESCRIPTION
# Description

FreeBSD does not have a separate package for RELP support.  This change allows the cookbook to function on FreeBSD systems.

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
