### PR TITLE
Chef 17 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           - 'centos-7'
           - 'centos-8'
           - 'fedora-latest'
-          - 'ubuntu-1604'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
           - 'opensuse-leap-15'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ This file is used to list changes made in each version of the rsyslog cookbook.
 
 ## Unreleased
 
+- Chef 17 updates: enable `unified_mode` on all resources
+- Bump required Chef Infra Client to >= 15.3
+- Remove support and testing for RHEL 6 and Ubuntu 16.04
+
 ## 8.0.3 - *2021-06-01*
+
+- Standardise files with files in sous-chefs/repo-management
 
 ## 8.0.2 - *2021-04-14*
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 13+
+- Chef 15.3+
 
 ### Other
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,14 +145,8 @@ when 'rhel', 'fedora', 'amazon'
     'uucp,news.crit' => "#{node['rsyslog']['default_log_dir']}/spooler",
     'local7.*' => "#{node['rsyslog']['default_log_dir']}/boot.log",
   }
-  # journald is used in systemd
-  if node['init_package'] == 'systemd'
-    default['rsyslog']['modules'] = %w(imuxsock imjournal)
-    default['rsyslog']['additional_directives'] = { 'OmitLocalLogging' => 'on', 'IMJournalStateFile' => 'imjournal.state' }
-  else
-    # RainerScript is not well supported by default on older RHEL
-    default['rsyslog']['config_style'] = 'legacy'
-  end
+  default['rsyslog']['modules'] = %w(imuxsock imjournal)
+  default['rsyslog']['additional_directives'] = { 'OmitLocalLogging' => 'on', 'IMJournalStateFile' => 'imjournal.state' }
 else
   # format { facility => destination }
   default['rsyslog']['default_facility_logs'] = {

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -58,13 +58,6 @@ platforms:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,7 +18,6 @@ platforms:
   - name: debian-10
   - name: fedora-latest
   - name: opensuse-leap-15
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures rsyslog'
 version           '8.0.3'
 source_url        'https://github.com/sous-chefs/rsyslog'
 issues_url        'https://github.com/sous-chefs/rsyslog/issues'
-chef_version      '>= 13'
+chef_version      '>= 15.3'
 
 supports 'amazon'
 supports 'centos'

--- a/resources/file_input.rb
+++ b/resources/file_input.rb
@@ -23,6 +23,8 @@ property :input_parameters, Hash, default: {}
 property :cookbook_source, String, default: 'rsyslog'
 property :template_source, String, default: lazy { labeled_template('file-input.conf.erb', node['rsyslog']['config_style']) }
 
+unified_mode true
+
 action :create do
   vars = {
     file_name: new_resource.file,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'rsyslog::client' do
   cached(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+    ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
       node.normal['rsyslog']['server_ip'] = server_ip
       node.normal['rsyslog']['custom_remote'] = custom_remote
     end.converge(described_recipe)
@@ -41,7 +41,7 @@ describe 'rsyslog::client' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11') do |node|
+        ChefSpec::ServerRunner.new(platform: 'smartos') do |node|
           node.normal['rsyslog']['server_ip'] = server_ip
           node.normal['rsyslog']['custom_remote'] = custom_remote
         end.converge(described_recipe)
@@ -84,7 +84,7 @@ describe 'rsyslog::client' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11') do |node|
+        ChefSpec::ServerRunner.new(platform: 'smartos') do |node|
           node.normal['rsyslog']['server_ip'] = server_ip
         end.converge(described_recipe)
       end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 describe 'rsyslog::default' do
   cached(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
+    ChefSpec::ServerRunner.new(platform: 'ubuntu').converge(described_recipe)
   end
-
   let(:service_resource) { 'service[rsyslog]' }
 
   it 'installs the rsyslog part' do
@@ -13,7 +12,7 @@ describe 'rsyslog::default' do
 
   context "when node['rsyslog']['relp'] is true" do
     cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+      ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
         node.normal['rsyslog']['use_relp'] = true
       end.converge(described_recipe)
     end
@@ -26,7 +25,7 @@ describe 'rsyslog::default' do
   context "when node['rsyslog']['enable_tls'] is true" do
     context "when node['rsyslog']['tls_ca_file'] is not set" do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
           node.normal['rsyslog']['enable_tls'] = true
         end.converge(described_recipe)
       end
@@ -38,7 +37,7 @@ describe 'rsyslog::default' do
 
     context "when node['rsyslog']['tls_ca_file'] is set" do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
           node.normal['rsyslog']['enable_tls'] = true
           node.normal['rsyslog']['tls_ca_file'] = '/etc/path/to/ssl-ca.crt'
         end.converge(described_recipe)
@@ -50,7 +49,7 @@ describe 'rsyslog::default' do
 
       context "when protocol is not 'tcp'" do
         cached(:chef_run) do
-          ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+          ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
             node.normal['rsyslog']['enable_tls'] = true
             node.normal['rsyslog']['tls_ca_file'] = '/etc/path/to/ssl-ca.crt'
             node.normal['rsyslog']['protocol'] = 'udp'
@@ -84,7 +83,7 @@ describe 'rsyslog::default' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11').converge(described_recipe)
+        ChefSpec::ServerRunner.new(platform: 'smartos').converge(described_recipe)
       end
 
       let(:directory) { chef_run.directory('/opt/local/etc/rsyslog.d') }
@@ -150,7 +149,7 @@ describe 'rsyslog::default' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11').converge(described_recipe)
+        ChefSpec::ServerRunner.new(platform: 'smartos').converge(described_recipe)
       end
 
       let(:template) { chef_run.template('/opt/local/etc/rsyslog.conf') }
@@ -203,7 +202,7 @@ describe 'rsyslog::default' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11').converge(described_recipe)
+        ChefSpec::ServerRunner.new(platform: 'smartos').converge(described_recipe)
       end
 
       let(:template) { chef_run.template('/opt/local/etc/rsyslog.d/50-default.conf') }
@@ -233,7 +232,7 @@ describe 'rsyslog::default' do
 
   context 'COOK-3608 maillog regression test' do
     cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'centos', version: '6').converge(described_recipe)
+      ChefSpec::ServerRunner.new(platform: 'centos').converge(described_recipe)
     end
 
     it 'outputs mail.* to /var/log/maillog' do
@@ -260,9 +259,9 @@ describe 'rsyslog::default' do
   end
 
   context 'when template[/etc/rsyslog.d/35-imfile.conf] receives :create' do
-    context 'when on centos 6' do
+    context 'when on centos' do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'centos', version: '6') do |node|
+        ChefSpec::ServerRunner.new(platform: 'centos') do |node|
           node.normal['rsyslog']['imfile']['PollingInterval'] = 10
         end.converge(described_recipe)
       end
@@ -272,15 +271,12 @@ describe 'rsyslog::default' do
         template.run_action(:create)
       end
 
-      it "node['rsyslog']['config_style'] will be 'legacy' by default" do
-        expect(chef_run.node['rsyslog']['config_style']).to eq('legacy')
-      end
       context '/etc/rsyslog.d/35-imfile.conf file' do
-        it 'will be create with legacy style syntax' do
-          expect(chef_run).to render_file(template.path).with_content('$ModLoad imfile')
+        it do
+          expect(chef_run).to_not render_file(template.path).with_content('$ModLoad imfile')
         end
-        it 'will NOT include module parameter PollingInterval' do
-          expect(chef_run).not_to render_file(template.path).with_content('PollingInterval')
+        it do
+          expect(chef_run).to render_file(template.path).with_content('PollingInterval')
         end
         it 'is owned by root:root' do
           expect(template.owner).to eq('root')
@@ -296,9 +292,9 @@ describe 'rsyslog::default' do
         end
       end
     end
-    context 'when on ubuntu 16.04 ' do
+    context 'when on ubuntu' do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
           node.normal['rsyslog']['imfile']['PollingInterval'] = 10
         end.converge(described_recipe)
       end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'rsyslog::server' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+    ChefSpec::ServerRunner.new(platform: 'ubuntu') do |node|
       node.default['rsyslog']['server'] = false
     end.converge(described_recipe)
   end
@@ -56,7 +56,7 @@ describe 'rsyslog::server' do
 
     context 'on SmartOS' do
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11') do |node|
+        ChefSpec::ServerRunner.new(platform: 'smartos') do |node|
           node.default['rsyslog']['server'] = false
         end.converge(described_recipe)
       end
@@ -84,7 +84,7 @@ describe 'rsyslog::server' do
 
   context '/etc/rsyslog.d/49-remote.conf file' do
     cached(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
+      ChefSpec::ServerRunner.new(platform: 'ubuntu').converge(described_recipe)
     end
 
     before do
@@ -109,7 +109,7 @@ describe 'rsyslog::server' do
       end
 
       cached(:chef_run) do
-        ChefSpec::ServerRunner.new(platform: 'smartos', version: '5.11') do |node|
+        ChefSpec::ServerRunner.new(platform: 'smartos') do |node|
           node.override['rsyslog']['server'] = false
         end.converge(described_recipe)
       end


### PR DESCRIPTION
- Chef 17 updates: enable `unified_mode` on all resources
- Bump required Chef Infra Client to >= 15.3
- Remove support and testing for RHEL 6 and Ubuntu 16.04

Signed-off-by: Lance Albertson <lance@osuosl.org>
