### PR TITLE
Allow $MaxMessageSize to be omitted from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the rsyslog cookbook.
 
 ## Unreleased
 
+- Allow omitting $MaxMessageSize from config
+
 ## 9.1.0 - *2022-02-26*
 
 - Use `gnutls` for TLS support on CentOS 7

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['priv_seperation']` - Whether to use privilege separation or not.
 - `node['rsyslog']['priv_user']` - User to run as when using privilege separation. Defult is `node['rsyslog']['user']`
 - `node['rsyslog']['priv_group']` - Group to run as when using privilege separation. Defult is `node['rsyslog']['group']`
-- `node['rsyslog']['max_message_size']` - Specify the maximum allowed message size. Default is 2k.
+- `node['rsyslog']['max_message_size']` - Specify the maximum allowed message size. Default is 2k. Specifying 'nil' or 'false' will not generate the associated directive in the configuration at all.
 - `node['rsyslog']['user']` - Who should own the configuration files and directories
 - `node['rsyslog']['group']` - Who should group-own the configuration files and directories
 - `node['rsyslog']['dir_owner']` - Who should own the log directories

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -21,7 +21,17 @@ describe 'rsyslog::default' do
     default_attributes['rsyslog']['max_message_size'] = nil
 
     it do
-      is_expected.to_not render_file('/etc/rsyslog.conf').with_content(/\$MaxMessageSize \s+/mix)
+      is_expected.to_not render_file('/etc/rsyslog.conf')
+        .with_content(/\$MaxMessageSize \s+/mix)
+    end
+  end
+
+  context "when node['rsyslog']['max_message_size'] is set" do
+    default_attributes['rsyslog']['max_message_size'] = '4k'
+
+    it do
+      is_expected.to render_file('/etc/rsyslog.conf')
+        .with_content(/\$MaxMessageSize \s+ 4k/mix)
     end
   end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -17,6 +17,14 @@ describe 'rsyslog::default' do
     end
   end
 
+  context "when node['rsyslog']['max_message_size'] is nil" do
+    default_attributes['rsyslog']['max_message_size'] = nil
+
+    it do
+      is_expected.to_not render_file('/etc/rsyslog.conf').with_content(%r{\$MaxMessageSize \s+}mix)
+    end
+  end
+
   context "when node['rsyslog']['enable_tls'] is true" do
     default_attributes['rsyslog']['enable_tls'] = true
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -21,7 +21,7 @@ describe 'rsyslog::default' do
     default_attributes['rsyslog']['max_message_size'] = nil
 
     it do
-      is_expected.to_not render_file('/etc/rsyslog.conf').with_content(%r{\$MaxMessageSize \s+}mix)
+      is_expected.to_not render_file('/etc/rsyslog.conf').with_content(/\$MaxMessageSize \s+/mix)
     end
   end
 

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -15,7 +15,9 @@ $LocalHostName <%= node['rsyslog']['local_host_name'] %>
 #
 # Set max message size
 #
+<% if node['rsyslog']['max_message_size'] -%>
 $MaxMessageSize <%= node['rsyslog']['max_message_size'] %>
+<% end %>
 
 #
 # Preserve FQDN


### PR DESCRIPTION
  - Update template to not emit $MaxMessageSize if attr is nil/false
  - Update README.md for attr that nil/false are now valid

# Description

Allows specifying nil/false for `node['rsyslog']['max_message_size']`, so that `$MaxMessageSize` is not emitted into /etc/rsyslog.conf

## Issues Resolved

https://github.com/sous-chefs/rsyslog/issues/196

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
