### PR TITLE
Make `$InputTCPMaxSessions` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of the rsyslog cookbook.
 
 ## Unreleased
 
+Make `$InputTCPMaxSessions` configurable via
+`node['rsyslog']['tcp_max_sessions']` attribute.
+
 ## 9.2.17 - *2023-12-21*
 
 ## 9.2.16 - *2023-09-28*

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ See `attributes/default.rb` for default values.
 - `node['rsyslog']['rate_limit_interval']` - Value of the $SystemLogRateLimitInterval configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
 - `node['rsyslog']['rate_limit_burst']` - Value of the $SystemLogRateLimitBurst configuration directive in `/etc/rsyslog.conf`. Default is nil, leaving it to the platform default.
 - `node['rsyslog']['action_queue_max_disk_space']` - Max amount of disk space the disk-assisted queue is allowed to use ([more info](http://www.rsyslog.com/doc/queues.html)).
+- `node['rsyslog']['tcp_max_sessions']` - Maximum number of TCP sessions (ie. clients) this rsyslog server will handle. Default is 200.
 - `node['rsyslog']['enable_tls']` - Whether or not to enable TLS encryption. When enabled, forces protocol to `tcp`. Default is `false`.
 - `node['rsyslog']['tls_driver']` -  Defaults to `ossl`.
 - `node['rsyslog']['tls_ca_file']` - Path to TLS CA file. Required for both server and clients.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,6 +50,7 @@ default['rsyslog']['tls_driver']                = if platform_family?('rhel') &&
                                                     'ossl'
                                                   end
 default['rsyslog']['action_queue_max_disk_space'] = '1G'
+default['rsyslog']['tcp_max_sessions']          = 200
 default['rsyslog']['tls_ca_file']               = nil
 default['rsyslog']['tls_certificate_file']      = nil
 default['rsyslog']['tls_key_file']              = nil

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -77,6 +77,9 @@ suites:
       inspec_tests:
         - name: rsyslog-default-integration-tests
           path: test/integration/default
+    attributes:
+      rsyslog:
+        tcp_max_sessions: 123
 
   - name: input_file_resource
     attributes:

--- a/templates/default/rsyslog.conf.erb
+++ b/templates/default/rsyslog.conf.erb
@@ -44,6 +44,7 @@ $DefaultNetstreamDriverKeyFile <%= node['rsyslog']['tls_key_file'] %>
 
 $ModLoad imtcp
 
+$InputTCPMaxSessions <%= node['rsyslog']['tcp_max_sessions'] || 200 %>
 $InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
 $InputTCPServerStreamDriverAuthMode <%= node['rsyslog']['tls_auth_mode'] || 'anon' %>
 $InputTCPServerRun <%= node['rsyslog']['port'] %>
@@ -51,6 +52,7 @@ $InputTCPServerRun <%= node['rsyslog']['port'] %>
   <% else -%>
 <% if node['rsyslog']['protocol'] =~ /tcp/ %>
   $ModLoad imtcp
+  $InputTCPMaxSessions <%= node['rsyslog']['tcp_max_sessions'] || 200 %>
   $InputTCPServerRun <%= node['rsyslog']['port'] %>
 <% end -%>
 <% if node['rsyslog']['protocol'] =~ /udp/ %>

--- a/test/integration/server/controls/server_spec.rb
+++ b/test/integration/server/controls/server_spec.rb
@@ -1,7 +1,7 @@
 control 'server' do
   describe file '/etc/rsyslog.conf' do
     it { should be_file }
-    its(:content) { should match %r{^\$InputTCPMaxSessions 123$} }
+    its(:content) { should match /^\$InputTCPMaxSessions 123$/ }
   end
 
   describe file '/etc/rsyslog.d/35-server-per-host.conf' do

--- a/test/integration/server/controls/server_spec.rb
+++ b/test/integration/server/controls/server_spec.rb
@@ -1,4 +1,9 @@
 control 'server' do
+  describe file '/etc/rsyslog.conf' do
+    it { should be_file }
+    its(:content) { should match %r{^\$InputTCPMaxSessions 123$} }
+  end
+
   describe file '/etc/rsyslog.d/35-server-per-host.conf' do
     it { should be_file }
   end


### PR DESCRIPTION
# Description

The implicit default for TCP sessions handled by rsyslog is 200. 
This is not sufficient for a loghost receiving logs from many nodes. 
Therefore we add a node attribute to make this setting configurable. 
The config in legacy format must happen before the first occurrence of `$InputTCPServerRun` according to the docs.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
