### PR TITLE
feat: Add service actions to client and server resources

### DIFF
--- a/documentation/rsyslog_client.md
+++ b/documentation/rsyslog_client.md
@@ -4,10 +4,14 @@ Configures rsyslog to forward logs to remote syslog servers.
 
 ## Actions
 
-| Action    | Description                                                                |
-| --------- | -------------------------------------------------------------------------- |
-| `:create` | Installs/configures rsyslog and renders remote forwarding config. Default. |
-| `:delete` | Removes client forwarding config and the base service artifacts.           |
+| Action     | Description                                                                |
+| ---------- | -------------------------------------------------------------------------- |
+| `:create`  | Installs/configures rsyslog and renders remote forwarding config. Default. |
+| `:delete`  | Removes client forwarding config and the base service artifacts.           |
+| `:start`   | Starts the rsyslog systemd unit.                                           |
+| `:stop`    | Stops the rsyslog systemd unit.                                            |
+| `:restart` | Restarts the rsyslog systemd unit.                                         |
+| `:reload`  | Reloads the rsyslog systemd unit.                                          |
 
 ## Properties
 

--- a/documentation/rsyslog_server.md
+++ b/documentation/rsyslog_server.md
@@ -4,10 +4,14 @@ Configures an rsyslog server that receives remote logs and writes per-host log f
 
 ## Actions
 
-| Action    | Description                                                                   |
-| --------- | ----------------------------------------------------------------------------- |
-| `:create` | Installs/configures rsyslog as a server and renders per-host config. Default. |
-| `:delete` | Removes server config, log directory, and base service artifacts.             |
+| Action     | Description                                                                   |
+| ---------- | ----------------------------------------------------------------------------- |
+| `:create`  | Installs/configures rsyslog as a server and renders per-host config. Default. |
+| `:delete`  | Removes server config, log directory, and base service artifacts.             |
+| `:start`   | Starts the rsyslog systemd unit.                                              |
+| `:stop`    | Stops the rsyslog systemd unit.                                               |
+| `:restart` | Restarts the rsyslog systemd unit.                                            |
+| `:reload`  | Reloads the rsyslog systemd unit.                                             |
 
 ## Properties
 

--- a/resources/rsyslog_client.rb
+++ b/resources/rsyslog_client.rb
@@ -121,3 +121,27 @@ action :delete do
     action :delete
   end
 end
+
+action :start do
+  systemd_unit rsyslog_service_unit do
+    action :start
+  end
+end
+
+action :stop do
+  systemd_unit rsyslog_service_unit do
+    action :stop
+  end
+end
+
+action :restart do
+  systemd_unit rsyslog_service_unit do
+    action :restart
+  end
+end
+
+action :reload do
+  systemd_unit rsyslog_service_unit do
+    action :reload
+  end
+end

--- a/resources/rsyslog_server.rb
+++ b/resources/rsyslog_server.rb
@@ -85,3 +85,27 @@ action :delete do
     action :delete
   end
 end
+
+action :start do
+  systemd_unit rsyslog_service_unit do
+    action :start
+  end
+end
+
+action :stop do
+  systemd_unit rsyslog_service_unit do
+    action :stop
+  end
+end
+
+action :restart do
+  systemd_unit rsyslog_service_unit do
+    action :restart
+  end
+end
+
+action :reload do
+  systemd_unit rsyslog_service_unit do
+    action :reload
+  end
+end

--- a/spec/unit/resources/rsyslog_client_spec.rb
+++ b/spec/unit/resources/rsyslog_client_spec.rb
@@ -52,4 +52,14 @@ describe 'rsyslog_client' do
 
     it { expect { chef_run }.to raise_error(RuntimeError, /no IP/) }
   end
+
+  context 'restart action' do
+    recipe do
+      rsyslog_client 'default' do
+        action :restart
+      end
+
+      it { is_expected.to restart_service('rsyslog.service') }
+    end
+  end
 end

--- a/spec/unit/resources/rsyslog_client_spec.rb
+++ b/spec/unit/resources/rsyslog_client_spec.rb
@@ -53,13 +53,43 @@ describe 'rsyslog_client' do
     it { expect { chef_run }.to raise_error(RuntimeError, /no IP/) }
   end
 
+  context 'start action' do
+    recipe do
+      rsyslog_client 'default' do
+        action :start
+      end
+    end
+
+    it { is_expected.to start_systemd_unit('rsyslog.service') }
+  end
+
+  context 'stop action' do
+    recipe do
+      rsyslog_client 'default' do
+        action :stop
+      end
+    end
+
+    it { is_expected.to stop_systemd_unit('rsyslog.service') }
+  end
+
   context 'restart action' do
     recipe do
       rsyslog_client 'default' do
         action :restart
       end
-
-      it { is_expected.to restart_service('rsyslog.service') }
     end
+
+    it { is_expected.to restart_systemd_unit('rsyslog.service') }
+  end
+
+  context 'reload action' do
+    recipe do
+      rsyslog_client 'default' do
+        action :reload
+      end
+    end
+
+    it { is_expected.to reload_systemd_unit('rsyslog.service') }
   end
 end

--- a/spec/unit/resources/rsyslog_server_spec.rb
+++ b/spec/unit/resources/rsyslog_server_spec.rb
@@ -38,4 +38,14 @@ describe 'rsyslog_server' do
       is_expected.to render_file('/etc/rsyslog.conf').with_content('Port="5514"')
     end
   end
+
+  context 'restart action' do
+    recipe do
+      rsyslog_server 'default' do
+        action :restart
+      end
+
+      it { is_expected.to restart_service('rsyslog.service') }
+    end
+  end
 end

--- a/spec/unit/resources/rsyslog_server_spec.rb
+++ b/spec/unit/resources/rsyslog_server_spec.rb
@@ -39,13 +39,43 @@ describe 'rsyslog_server' do
     end
   end
 
+  context 'start action' do
+    recipe do
+      rsyslog_server 'default' do
+        action :start
+      end
+    end
+
+    it { is_expected.to start_systemd_unit('rsyslog.service') }
+  end
+
+  context 'stop action' do
+    recipe do
+      rsyslog_server 'default' do
+        action :stop
+      end
+    end
+
+    it { is_expected.to stop_systemd_unit('rsyslog.service') }
+  end
+
   context 'restart action' do
     recipe do
       rsyslog_server 'default' do
         action :restart
       end
-
-      it { is_expected.to restart_service('rsyslog.service') }
     end
+
+    it { is_expected.to restart_systemd_unit('rsyslog.service') }
+  end
+
+  context 'reload action' do
+    recipe do
+      rsyslog_server 'default' do
+        action :reload
+      end
+    end
+
+    it { is_expected.to reload_systemd_unit('rsyslog.service') }
   end
 end

--- a/spec/unit/resources/rsyslog_service_spec.rb
+++ b/spec/unit/resources/rsyslog_service_spec.rb
@@ -70,4 +70,14 @@ describe 'rsyslog_service' do
     it { is_expected.to render_file('/etc/rsyslog.conf').with_content(/^module\(load="imjournal".*StateFile=/) }
     it { is_expected.to render_file('/etc/rsyslog.d/50-default.conf').with_content('mail.*    -/var/log/maillog') }
   end
+
+  context 'restart action' do
+    recipe do
+      rsyslog_service 'default' do
+        action :restart
+      end
+
+      it { is_expected.to restart_service('rsyslog.service') }
+    end
+  end
 end

--- a/spec/unit/resources/rsyslog_service_spec.rb
+++ b/spec/unit/resources/rsyslog_service_spec.rb
@@ -71,13 +71,43 @@ describe 'rsyslog_service' do
     it { is_expected.to render_file('/etc/rsyslog.d/50-default.conf').with_content('mail.*    -/var/log/maillog') }
   end
 
+  context 'start action' do
+    recipe do
+      rsyslog_service 'default' do
+        action :start
+      end
+    end
+
+    it { is_expected.to start_systemd_unit('rsyslog.service') }
+  end
+
+  context 'stop action' do
+    recipe do
+      rsyslog_service 'default' do
+        action :stop
+      end
+    end
+
+    it { is_expected.to stop_systemd_unit('rsyslog.service') }
+  end
+
   context 'restart action' do
     recipe do
       rsyslog_service 'default' do
         action :restart
       end
-
-      it { is_expected.to restart_service('rsyslog.service') }
     end
+
+    it { is_expected.to restart_systemd_unit('rsyslog.service') }
+  end
+
+  context 'reload action' do
+    recipe do
+      rsyslog_service 'default' do
+        action :reload
+      end
+    end
+
+    it { is_expected.to reload_systemd_unit('rsyslog.service') }
   end
 end


### PR DESCRIPTION
# Description

- Add `:start`, `:stop`, `:restart`, and `:reload` actions for the `rsyslog_client` and `rsyslog_server` resources
- Add unit testing for the `:start`, `:stop`, `:restart`, and `:reload` actions for the `rsyslog_service`, `rsyslog_client`, and `rsyslog_server` resources

## Issues Resolved

None

## Check List

- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [x] New functionality includes testing
- [x] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)
